### PR TITLE
Graphy

### DIFF
--- a/resources/filters.js
+++ b/resources/filters.js
@@ -244,7 +244,11 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search,d
     var output=compare(link,link);
     return output;
   }
-   
+  else if(domain=="graphy.com"){
+    link=hostname;
+    var output=compare(link,link);
+    return output;
+  } 
 					
 	else{ link=domain;
     var output= compare(link,hostname);

--- a/resources/filters.js
+++ b/resources/filters.js
@@ -239,6 +239,11 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search,d
     var output = compare(link,link);
     return output;
   } 
+  else if(domain=="myinstamojo.com"){
+    link=hostname;
+    var output=compare(link,link);
+    return output;
+  }
    
 					
 	else{ link=domain;


### PR DESCRIPTION
Add support for graphy.com

Creators use graphy.com to sell digital products and memberships.
Related Issue: [Graphy](https://github.com/authifyWeb/URL-Frontend/issues/126)