### PR TITLE
Add graphy.com filters

### DIFF
--- a/resources/filters.js
+++ b/resources/filters.js
@@ -244,6 +244,11 @@ export function filtering(url, href, origin, hostname,protocol,pathname,search,d
     var output=compare(link,link);
     return output;
   }
+  else if(domain=="graphy.com"){
+    link=hostname;
+    var output=compare(link,link);
+    return output;
+  } 
    
 					
 	else{ link=domain;


### PR DESCRIPTION
Content creators use this website to sell digital products and memberships.
Related: [Graphy](https://github.com/authifyWeb/URL-Frontend/issues/126)